### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@ set (RangeTree_VERSION_MINOR 1)
 find_package(Threads REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    add_definitions(-Wall -ansi -Wno-deprecated -pthread)
+    add_definitions(-Wall -ansi -Wno-deprecated)
 endif()
 
 # Flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 11)
 
 #-------------------
 # set common include folder for module
@@ -36,26 +36,6 @@ set(EXT_PROJECTS_DIR ${PROJECT_SOURCE_DIR}/ext)
 #add_library(${PROJECT_LIB_NAME} ${SRC_FILES})
 #
 add_subdirectory(${EXT_PROJECTS_DIR}/gtest)
-
-#-------------------
-# Profiling
-#-------------------
-add_definitions(${MSVC_COMPILER_DEFS})
-set(PROFILING_NAME ${PROJECT_NAME_STR}_prof)
-include_directories(${COMMON_INCLUDES})
-
-file(GLOB PROF_SRC_FILES ${PROJECT_SOURCE_DIR}/profiling_test.cpp)
-add_executable(${PROFILING_NAME} ${PROF_SRC_FILES})
-
-#target_link_libraries(${PROFILING_NAME} ${PROJECT_LIB_NAME})
-target_link_libraries(${PROFILING_NAME} ${CMAKE_THREAD_LIBS_INIT})
-
-# including boost
-#set(Boost_INCLUDE_DIR /usr/local/Cellar/boost/1.64.0_1/include)
-#set(Boost_LIBRARY_DIR /usr/local/Cellar/boost/1.64.0_1/lib)
-#find_package(Boost 1.61.0 COMPONENTS system filesystem REQUIRED)
-#include_directories(${Boost_INCLUDE_DIRS})
-#target_link_libraries(${PROFILING_NAME} ${Boost_LIBRARIES})
 
 #-------------------
 # Test

--- a/RangeTree.h
+++ b/RangeTree.h
@@ -43,6 +43,7 @@
 #include <type_traits>
 #include <deque>
 #include <cmath>
+#include <algorithm>
 
 namespace RangeTree {
 

--- a/ext/gtest/CMakeLists.txt
+++ b/ext/gtest/CMakeLists.txt
@@ -28,7 +28,5 @@ set(GTEST_INCLUDE_DIRS ${source_dir}/googletest/include PARENT_SCOPE)
 
 # Specify MainTest's link libraries
 ExternalProject_Get_Property(googletest binary_dir)
-set(GTEST_LIBS_DIR ${binary_dir}/googlemock/gtest PARENT_SCOPE)
-
-
+set(GTEST_LIBS_DIR ${binary_dir}/lib PARENT_SCOPE)
 


### PR DESCRIPTION
Resolves #1. Builds on Ubuntu 16.04 with CMake 3.12.1 and g++ 8.4.0.

The following changes were necessary:
* Add `<algorithm>` header to RangeTree.h
* Use standard CMake variable `CMAKE_CXX_STANDARD` instead of manually setting the flag for C++11.
* Redirect Gtest link location