### PR TITLE
Fix sorting predicate passing points array by value

### DIFF
--- a/RangeTree.h
+++ b/RangeTree.h
@@ -305,7 +305,7 @@ namespace RangeTree {
             for (int i = 0; i < points.size(); i++) { order[i] = i; }
             PointOrdering<T,S> pointOrdering(onDim);
             std::sort(order.begin(), order.end(),
-                      [pointOrdering, points](int i, int j) {
+                      [&pointOrdering, &points](int i, int j) {
                           return pointOrdering.less(*(points[i]), *(points[j]));
                       });
             return order;


### PR DESCRIPTION
One of the sorts inside of SortedPointMatrix passes the points array by value on every comparison.  This was causing the range tree initialization to take minutes instead of seconds.

I have personally tested this change based on my own project use of the range tree, but I can't run the provided tests anymore.  The build is broken.